### PR TITLE
Enforce indentation

### DIFF
--- a/GlpiStandard/ruleset.xml
+++ b/GlpiStandard/ruleset.xml
@@ -18,6 +18,7 @@
   <!-- Indent 3 -->
   <rule ref="Generic.WhiteSpace.ScopeIndent">
     <properties>
+      <property name="exact" value="true"/>
       <property name="indent" value="3"/>
     </properties>
   </rule>


### PR DESCRIPTION
Current rule defines the minimum of space for indentation, but not for max