### PR TITLE
Update dependencies to ensure compatibility with PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/glpi-project/coding-standard/issues"
     },
     "require": {
-        "slevomat/coding-standard": "^6.3",
-        "squizlabs/php_codesniffer": "^3.5.5"
+        "slevomat/coding-standard": "^7.0",
+        "squizlabs/php_codesniffer": "^3.6"
     }
 }


### PR DESCRIPTION
I propose to upgrade minimum supported version of required libs, to ensure that fetched versions are compatible with PHP 8.0.