### PR TITLE
Remove '#' comments disallow rule to permit usage of PHP attributes

### DIFF
--- a/GlpiStandard/ruleset.xml
+++ b/GlpiStandard/ruleset.xml
@@ -34,9 +34,6 @@
   <!--  Makes sure that shorthand PHP open tags are not used. -->
   <rule ref="Generic.PHP.DisallowShortOpenTag"/>
 
-  <!--  Checks that no perl-style comments (#) are used. -->
-  <rule ref="PEAR.Commenting.InlineComment"/>
-
   <!-- No white spaces after opening bracket and before closing bracket in IF -->
   <rule ref="PSR2.ControlStructures.ControlStructureSpacing" />
 


### PR DESCRIPTION
To prevent deprecation errors on PHP 8.1, one may want to use the `#[ReturnTypeWillChange]` attribute (see https://wiki.php.net/rfc/internal_method_return_types).

I did it on GLPI (see https://github.com/glpi-project/glpi/pull/9663), but lint on PHP 7.4 failed as in PHP < 8, PHP attributes are considered as Perl-style comments (see https://github.com/glpi-project/glpi/runs/3820110872?check_suite_focus=true).

Having Perl-style comments is not really a problem while using PHP attributes may be necessary, so I propose to drop this rule.